### PR TITLE
API endpoint bollards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased](https://github.com/Amsterdam/bereikbaarheid-backend/compare/v2.3.1...HEAD)
+## [Unreleased](https://github.com/Amsterdam/bereikbaarheid-backend/compare/v2.3.2...HEAD)
+
+### Added
+- Bollards API endpoint
 
 
 ## [v2.3.2 - 2023-06-05](https://github.com/Amsterdam/bereikbaarheid-backend/compare/v2.3.1...v2.3.2)

--- a/src/app/api/__init__.py
+++ b/src/app/api/__init__.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify
 api = Blueprint("api", __name__)
 
 from . import roads  # noqa: E402  # imports needs to be after Blueprint init
+from . import bollards  # noqa: E402
 from . import permits  # noqa: E402
 from . import isochrones  # noqa: E402
 from . import road_elements  # noqa: E402

--- a/src/app/api/bollards.py
+++ b/src/app/api/bollards.py
@@ -133,7 +133,7 @@ def query_db_bollards(day_of_the_week, lat, lon, time_from, time_to):
             left join bereikbaarheid.out_vma_directed g
             on g.id = routing.edge
 
-            left join bereikbaarheid.bd_verzinkbare_palen pp
+            left join bereikbaarheid.bd_verkeerspalen pp
             on abs(routing.edge) = pp.linknr
             where paalnummer is not null
 
@@ -220,7 +220,7 @@ def prepare_pgr_dijkstra_cost_query(day_of_the_week, time_from, time_to):
 
             from bereikbaarheid.out_vma_directed v
 
-            left join bereikbaarheid.bd_verzinkbare_palen p
+            left join bereikbaarheid.bd_verkeerspalen p
             on abs(v.id) = abs(p.linknr)
             where car_network = true
             or abs(id) in (

--- a/src/app/api/bollards.py
+++ b/src/app/api/bollards.py
@@ -1,0 +1,241 @@
+from marshmallow import (
+    Schema,
+    fields,
+    validate,
+    validates_schema,
+    ValidationError,
+)
+from webargs.flaskparser import use_args
+
+from .validation import bbox_adam, days_of_the_week_abbreviated
+from . import api
+from ..db import get_db, query_db
+
+
+class BollardsValidationSchema(Schema):
+    dayOfTheWeek = fields.String(
+        required=True,
+        validate=validate.OneOf(days_of_the_week_abbreviated),
+    )
+
+    lat = fields.Float(
+        required=True,
+        validate=[
+            validate.Range(
+                min=bbox_adam["lat"]["min"], max=bbox_adam["lat"]["max"]
+            )
+        ],
+    )
+
+    lon = fields.Float(
+        required=True,
+        validate=[
+            validate.Range(
+                min=bbox_adam["lon"]["min"], max=bbox_adam["lon"]["max"]
+            )
+        ],
+    )
+
+    timeFrom = fields.Time(
+        format="%H:%M",
+        required=True,
+    )
+
+    timeTo = fields.Time(
+        format="%H:%M",
+        required=True,
+    )
+
+    @validates_schema
+    def validate_dates(self, data, **kwargs):
+        if data["timeTo"] < data["timeFrom"]:
+            raise ValidationError("TimeTo must be later than timeFrom")
+
+
+@api.get("/bollards/")
+@use_args(BollardsValidationSchema(), location="query")
+def bollards(args):
+    result = query_db_bollards(
+        args["dayOfTheWeek"],
+        args["lat"],
+        args["lon"],
+        args["timeFrom"],
+        args["timeTo"],
+    )
+
+    # https://datatracker.ietf.org/doc/html/rfc7946#section-3.3
+    return {
+        "type": "FeatureCollection",
+        "features": [i[0] for i in result] if result else [],
+    }
+
+
+def query_db_bollards(day_of_the_week, lat, lon, time_from, time_to):
+    """
+    The query calculates a route to the provided lat/lon and returns
+    the encountered bollards. If no bollards are found, nothing is returned.
+
+    It works as follows:
+    - Based on the provided day of the week, start and end time,
+      the network cost is recalculated:
+      - cost is multiplied by 10000 if:
+        - road section is linked to a bollard
+        - AND the given day, start and end time do not match with the times
+          when the bollard is retracted / removed
+      - cost is multiplied by 10000 * 10000 if:
+        - road section is linked to a bollard
+        - AND the given day, start and end time do not match with the times
+          when the bollard is retracted / removed
+        - AND road section is not accessible for vehicles
+      - cost is multiplied by 2 * 10000 * 10000 if:
+        - road section is not accessible for vehicles
+      - for all other cases, the normal cost calculation (length/speed) applies
+    - By recalculating the cost - as described above - the routing algorithm
+      will try to find a route without bollards. It will only use routes
+      with bollard(s) if all other options are exhausted.
+    - The provided lat/lon is used to search for the closest target node
+    - The closest target node is used for calculating routes
+
+    :param day_of_the_week: string - e.g "di"
+    :param time_from: string - e.g "08:00:00"
+    :param time_to: string - e.g "16:00:00"
+    :param lat: float - the latitude of the location
+    :param lon: float - the longitude of the location
+    :return: object - bollards encountered while routing to a lat/lon
+             on a given day, start and end time.
+    """
+    db_query = """
+        with bollards as (
+            select pp.*
+            from pgr_dijkstra(
+                %(pgr_dijkstra_cost_query)s,
+                902205,
+                (
+                    select target
+                    from bereikbaarheid.out_vma_directed a
+                    where cost > 0 or car_network is false
+                    order by st_length(
+                        st_transform(
+                            st_shortestline(
+                                st_setsrid(
+                                    ST_MakePoint(%(lon)s, %(lat)s),
+                                    4326
+                                ),
+                                st_linemerge(a.geom4326)
+                            ),
+                            28992
+                        )
+                    ) asc
+                    limit 1
+                )
+            ) as routing
+
+            left join bereikbaarheid.out_vma_directed g
+            on g.id = routing.edge
+
+            left join bereikbaarheid.bd_verzinkbare_palen pp
+            on abs(routing.edge) = pp.linknr
+            where paalnummer is not null
+
+            order by seq
+        )
+
+        select json_build_object(
+            'geometry', ST_Transform(bollards.geometry, 4326)::json,
+            'properties', json_build_object(
+                'id', bollards.paalnummer,
+                'type', bollards.type,
+                'location', bollards.standplaats,
+                'days', bollards.dagen,
+                'start_time', bollards.begin_tijd,
+                'end_time', bollards.eind_tijd,
+                'entry_system', bollards.toegangssysteem
+            ),
+            'type', 'Feature'
+        )
+        from bollards
+    """
+
+    query_params = {
+        "pgr_dijkstra_cost_query": prepare_pgr_dijkstra_cost_query(
+            day_of_the_week, time_from, time_to
+        ),
+        "lat": lat,
+        "lon": lon,
+    }
+
+    try:
+        return query_db(db_query, query_params)
+
+    except Exception:
+        print("Error while retrieving bollards")
+
+
+def prepare_pgr_dijkstra_cost_query(day_of_the_week, time_from, time_to):
+    """
+    Helper function for the query_db_bollards function
+    Prepares a database query for use in the pgr_dijkstraCost db function
+
+    This preparation is needed because the pgr_dijkstraCost db function uses
+    psycopg placeholders. When defining this query inline - in the db_query
+    variable of the query_db_bollards function above - the %(time_to)s and
+    %(time_from)s placeholders cause a SQL syntax error (because the date's
+    are single-quoted within a single quoted statement). Therefore this query
+    is prepared first, and returned for use as a query parameter in the
+    query_db_bollards function.
+
+    :param day_of_the_week: string - e.g "di"
+    :param time_from: string - e.g "08:00:00"
+    :param time_to: string - e.g "16:00:00"
+    :return: prepared db query for use in the pgr_dijkstraCost db function
+    """
+
+    pgr_dijkstra_cost_query = """
+        select v.id,
+            v.source,
+            v.target,
+            v.car_network,
+            v.geom,
+
+            case
+                when car_network = true
+                    and %(day_of_the_week)s <> ANY(dagen)
+                    and begin_tijd <= %(time_from)s
+                    and eind_tijd >= %(time_to)s
+                    then cost * 10000
+                when car_network = false
+                    and %(day_of_the_week)s <> ANY(dagen)
+                    and begin_tijd <= %(time_from)s
+                    and eind_tijd >= %(time_to)s
+                    then 10000 * 10000
+                when car_network = false then 10000 * 10000 * 2
+                else cost
+            end as cost,
+
+            p.paalnummer,
+            p.dagen,
+            p.begin_tijd,
+            p.eind_tijd,
+            p.geometry
+
+            from bereikbaarheid.out_vma_directed v
+
+            left join bereikbaarheid.bd_verzinkbare_palen p
+            on abs(v.id) = abs(p.linknr)
+            where car_network = true
+            or abs(id) in (
+                select linknr from bereikbaarheid.bd_venstertijdwegen
+            )
+        """
+
+    pgr_dijkstra_cost_query_params = {
+        "day_of_the_week": day_of_the_week,
+        "time_from": time_from,
+        "time_to": time_to,
+    }
+
+    cursor = get_db().cursor()
+
+    return cursor.mogrify(
+        pgr_dijkstra_cost_query, pgr_dijkstra_cost_query_params
+    ).decode("utf-8")

--- a/src/app/api/validation.py
+++ b/src/app/api/validation.py
@@ -6,6 +6,8 @@ bbox_adam = {
     "lon": {"min": 4.7, "max": 5.1},
 }
 
+days_of_the_week_abbreviated = ["ma", "di", "wo", "do", "vr", "za", "zo"]
+
 # The vehicle parameters should be in sync with validation requirements
 # for client-side forms (defined in javascript)
 vehicle = {


### PR DESCRIPTION
Adds the `/bollards` API endpoint. The endpoint calculates a route to the provided lat/lon and returns the encountered bollards as a `FeatureCollection`. If no bollards are found, an empty `FeatureCollection` is returned.

The endpoint requires the following URL parameters:
- `dayOfTheWeek`, e.g `di`
- `lat`, e.g `52.371198`
- `lon`, e.g `4.8920418`
- `timeFrom`, e.g `10:00`
- `timeTo`, e.g `12:00`

example URL: `/v1/bollards/?dayOfTheWeek=di&lat=52.371198&lon=4.8920418&timeFrom=10:00&timeTo=12:00`